### PR TITLE
feat(rust): re-export prost_types crate

### DIFF
--- a/rust/edgehog-device-runtime-proto/src/lib.rs
+++ b/rust/edgehog-device-runtime-proto/src/lib.rs
@@ -6,4 +6,5 @@ pub mod containers;
 
 // Re-exported dependencies
 pub use prost;
+pub use prost_types;
 pub use tonic;


### PR DESCRIPTION
This will make the Timestamp type available to dependents.